### PR TITLE
Correction d'une misstake au niveau du token

### DIFF
--- a/test.py
+++ b/test.py
@@ -11,7 +11,7 @@ ent = input('Code de l\'ENT $ ')
 
 response = requests.post(api_url.rstrip('/') + '/generatetoken', data={'url': pronote_url, 'username': username, 'password': password, 'ent': ent})
 print('login effectué')
-token = response.json()
+token = response.json()['token']
 
 start = time.time()
 response = requests.get(api_url.rstrip('/') + '/user', params={'token': token})


### PR DESCRIPTION
Au début j'ai voulu essayer test.py, j'ai entré tout sans erreurs, puis toutes les requêtes renvoyaient not found, j'ai donc jeté un coup d'oeil au code et j'ai remarqué que le token qui était envoyé lors de la ligne suivant : response = requests.get(api_url.rstrip('/') + '/user', params={'token': token}), envoyait le token en format json, soit {"token": "{token}", "error": false} et donc que lors de la réponse l'API ne trouvait pas le token, j'ai donc corrigé le code de sorte a ce que le token soit égal a la clé "token" dans le json, de cette manière test.py renvoyait bel et bien les réponses 👍🏼 Avant : 
![papillon-python-issue](https://github.com/PapillonApp/papillon-python/assets/131205423/38955297-3f60-4ee5-afb6-678ee2961749) et après : 
![papillon-python-corrected](https://github.com/PapillonApp/papillon-python/assets/131205423/ecccc4cd-81a7-46cd-a782-671c0697e2b7)
