### PR TITLE
Build docker image for aarch64

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - development  # Changer en la branche que vous souhaitez surveiller
-  workflow_dispatch: # Pour lancer manuellement
 
 jobs:
   build_and_publish:
@@ -31,7 +30,7 @@ jobs:
           docker buildx create --use
           docker buildx build \
             --file Dockerfile \
-            --tag yayacout/papillonserver:latest \
+            --tag justtryon/papillonserver:latest \
             --platform linux/amd64,linux/aarch64 \
             .
       
@@ -40,6 +39,6 @@ jobs:
           docker buildx create --use
           docker buildx build \
             --file Dockerfile \
-            --tag yayacout/papillonserver:latest \
+            --tag justtryon/papillonserver:latest \
             --platform linux/amd64,linux/aarch64 \
             --push .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - development  # Changer en la branche que vous souhaitez surveiller
+  workflow_dispatch: # Pour lancer manuellement
 
 jobs:
   build_and_publish:
@@ -12,6 +13,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -27,7 +31,8 @@ jobs:
           docker buildx create --use
           docker buildx build \
             --file Dockerfile \
-            --tag justtryon/papillonserver:latest \
+            --tag yayacout/papillonserver:latest \
+            --platform linux/amd64,linux/aarch64 \
             .
       
       - name: Push Docker image to Docker Hub
@@ -35,5 +40,6 @@ jobs:
           docker buildx create --use
           docker buildx build \
             --file Dockerfile \
-            --tag justtryon/papillonserver:latest \
+            --tag yayacout/papillonserver:latest \
+            --platform linux/amd64,linux/aarch64 \
             --push .


### PR DESCRIPTION
Currently, the docker image is only built for `amd64`, which can't be executed on a Raspberry Pi (which is the easiest way to self-host the Papillon server).
Docker support building an image for multiple platforms using QEMU, so this pull request just adds `aarch64` to the list of targets. The principal downside is slower build (2m 28 for the dual image instead of 1m for the current image).

This pull request just adds QEMU setup to the GitHub workflow to have a dual-arch image.
I tried on my Raspberry, and it is working.
Image is here if you want to test : https://hub.docker.com/r/yayacout/papillonserver